### PR TITLE
MockBeanのdeprecated対応

### DIFF
--- a/docs/designs/20251018-4-design.md
+++ b/docs/designs/20251018-4-design.md
@@ -1,0 +1,50 @@
+# MockBeanのdeprecated対応設計
+
+## 概要
+
+BedrockControllerTest.javaにて使用している`@MockBean`アノテーションがdeprecatedとなっているため、新しい推奨方法に変更する。
+
+## 現状の問題
+
+- `@MockBean`アノテーションがdeprecatedになっている
+- Spring Boot 3.x系では`@MockBean`の代わりに`@MockitoBean`の使用が推奨されている
+
+## 対応方針
+
+### 1. アノテーションの変更
+
+- `@MockBean` → `@MockitoBean`に変更
+- 必要に応じてimport文も更新
+
+### 2. 依存関係の確認
+
+- `spring-boot-test`の依存関係を確認
+- Mockitoの依存関係が適切に設定されているか確認
+
+### 3. テストの動作確認
+
+- 変更後にテストが正常に動作することを確認
+- 既存のテストケースが全て通ることを確認
+
+## 修正対象ファイル
+
+- `src/test/java/com/example/springaiapp/controller/BedrockControllerTest.java`
+
+## 修正内容
+
+1. import文の変更
+   - `import org.springframework.boot.test.mock.mockito.MockBean;` を削除
+   - `import org.springframework.boot.test.mock.mockito.MockitoBean;` を追加
+
+2. アノテーションの変更
+   - `@MockBean private BedrockService bedrockService;` を `@MockitoBean private BedrockService bedrockService;` に変更
+
+## 検証方法
+
+- Gradleでテストを実行し、警告が出力されないことを確認
+- 全てのテストケースが正常に通ることを確認
+
+## 注意事項
+
+- Spring Boot 3.x系での推奨方法に従う
+- 他のテストファイルでも同様の問題がないか確認が必要

--- a/src/test/java/com/example/springaiapp/controller/BedrockControllerTest.java
+++ b/src/test/java/com/example/springaiapp/controller/BedrockControllerTest.java
@@ -9,7 +9,7 @@ import com.example.springaiapp.service.BedrockService;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
 /** BedrockControllerのテストクラス */
@@ -18,7 +18,7 @@ class BedrockControllerTest {
 
   @Autowired private MockMvc mockMvc;
 
-  @MockBean private BedrockService bedrockService;
+  @MockitoBean private BedrockService bedrockService;
 
   /** 正常系：メッセージ送信とレスポンス確認 */
   @Test


### PR DESCRIPTION
BedrockControllerTest.javaの@MockBeanをSpring Boot 3.5.6で推奨される@MockitoBeanに変更してdeprecated警告を解消しました。

## 変更内容
- import文を org.springframework.test.context.bean.override.mockito.MockitoBean に変更
- @MockBean アノテーションを @MockitoBean に変更

## 確認事項
- コンパイルエラーが解消されていることを確認済み
- deprecated警告が出力されないことを確認済み

Fixes #4